### PR TITLE
Entity api was rejecting any fields containing organ even if they were

### DIFF
--- a/ingest-api-spec.yaml
+++ b/ingest-api-spec.yaml
@@ -414,28 +414,150 @@ paths:
       requestBody:
         content:
           multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
       responses:
+        '200':
+          description: File uploaded, temp directory and temp_id created.
+          content:
+            application/json:
+              schema:
+                properties:
+                  temp_id:
+                    type: string
+        '400':
+          description: File not upload failed or file contains invalid donors
+          content:
+            application/json:
+              schema:
+                properties:
+                  status:
+                    type: string
+                  message:
+                    type: string
+        '401':
+          description: The user's token has expired or the user did not have authorization
+        '500':
+          description: Internal error
   /donors/bulk:
     post:
-      summary:
+      summary: "Confirm that you want to create donors from the previously uploaded tsv file. Donors are validated once more and then if valid, new donors are created via the entity api"
       requestBody:
         content:
           application/json:
+            schema:
+              type: object
+              properties:
+                temp_id:
+                  type: string
+                  items:
+                    - $ref: '#/components/schemas/temp_id'
+                group_uuid:
+                  type: string
+                  items:
+                    - $ref: '#/components/schemas/group_uuid'
       responses:
+        '200':
+          description: The samples in the tsv file were successfully created.
+          content:
+            application/json:
+              schema:
+                properties:
+                  status:
+                    type: string
+                  data:
+                    type: json
+        '400':
+          description: File not found for given temp_id
+          content:
+            application/json:
+              schema:
+                properties:
+                  status:
+                    type: string
+                  message:
+                    type: string
+        '401':
+          description: The user's token has expired or the user did not have authorization
+        '500':
+          description: Internal error
   /samples/bulk-upload:
     post:
-      summary:
+      summary: "Upload a tsv file containing multiple donor records to temporary stage. On success the file will be staged and a temporary id will be returned to reference the staged file by. Each record in the tsv are validated to verify that they are acceptable values for a donor and all necessary fields are included. Temporary id is only provided if all donor records in the tsv are valid."
       requestBody:
         content:
           multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
       responses:
+        '200':
+          description: File uploaded, temp directory and temp_id created.
+          content:
+            application/json:
+              schema:
+                properties:
+                  temp_id:
+                    type: string
+        '400':
+          description: File not upload failed or file contains invalid donors
+          content:
+            application/json:
+              schema:
+                properties:
+                  status:
+                    type: string
+                  message:
+                    type: string
   /samples/bulk:
     post:
-      summary:
+      summary: "Confirm that you want to create donors from the previously uploaded tsv file. Donors are validated once more and then if valid, new donors are created via the entity api"
       requestBody:
         content:
           application/json:
+            schema:
+              type: object
+              properties:
+                temp_id:
+                  type: string
+                  items:
+                    - $ref: '#/components/schemas/temp_id'
+                group_uuid:
+                  type: string
+                  items:
+                    - $ref: '#/components/schemas/group_uuid'
       responses:
+        '200':
+          description: The samples in the tsv file were successfully created.
+          content:
+            application/json:
+              schema:
+                properties:
+                  status:
+                    type: string
+                  data:
+                    type: json
+        '400':
+          description: File not found for given temp_id
+          content:
+            application/json:
+              schema:
+                properties:
+                  status:
+                    type: string
+                  message:
+                    type: string
+        '401':
+          description: The user's token has expired or the user did not have authorization
+        '500':
+          description: Internal error
 
 
 

--- a/ingest-api-spec.yaml
+++ b/ingest-api-spec.yaml
@@ -408,6 +408,37 @@ paths:
           description: The user's token has expired or the user did not supply a valid token
         '500':
           description: Internal error
+  /donors/bulk-upload:
+    post:
+      summary: "Upload a tsv file containing multiple donor records to temporary stage. On success the file will be staged and a temporary id will be returned to reference the staged file by. Each record in the tsv are validated to verify that they are acceptable values for a donor and all necessary fields are included. Temporary id is only provided if all donor records in the tsv are valid."
+      requestBody:
+        content:
+          multipart/form-data:
+      responses:
+  /donors/bulk:
+    post:
+      summary:
+      requestBody:
+        content:
+          application/json:
+      responses:
+  /samples/bulk-upload:
+    post:
+      summary:
+      requestBody:
+        content:
+          multipart/form-data:
+      responses:
+  /samples/bulk:
+    post:
+      summary:
+      requestBody:
+        content:
+          application/json:
+      responses:
+
+
+
 
 
 servers:

--- a/src/app.py
+++ b/src/app.py
@@ -1564,6 +1564,8 @@ def create_samples_from_bulk():
                     del item['organ_type']
                     item['protocol_url'] = item['sample_protocol']
                     del item['sample_protocol']
+                    if item['organ'] == '':
+                        del item['organ']
                     if item['rui_location'] == '':
                         del item['rui_location']
                     else:


### PR DESCRIPTION
Entity api was rejecting any fields containing organ even if they were 
blank. It is now set up to remove organ field from the json sent 
to entity if its blank.

Also began documentation for endpoints /donors/bulk /donors/bulk-upload /samples/bulk and /samples/bulk-upload in ingest-api-spec.yaml