### PR TITLE
Yuanzhou/url fix aws gateway

### DIFF
--- a/src/app_manager.py
+++ b/src/app_manager.py
@@ -16,17 +16,16 @@ logger = logging.getLogger(__name__)
 requests.packages.urllib3.disable_warnings(category = InsecureRequestWarning)
 
 
-def nexus_token_from_request_headers(request_headers: object) -> str:
+def groups_token_from_request_headers(request_headers: object) -> str:
     bearer_token = request_headers['AUTHORIZATION'].strip()
-    nexus_token = bearer_token[len('bearer '):].strip()
-    return nexus_token
+    groups_token = bearer_token[len('bearer '):].strip()
+    return groups_token
 
 
 def update_ingest_status_title_thumbnail(app_config: object, request_json: object, 
                                          request_headers: object, entity_api: EntityApi, 
                                          file_upload_helper_instance: UploadFileHelper) -> object:
     dataset_uuid = request_json['dataset_id'].strip()
-    nexus_token = nexus_token_from_request_headers(request_headers)
     dataset = Dataset(app_config)
     dataset_helper = DatasetHelper()
 
@@ -102,7 +101,7 @@ def update_ingest_status_title_thumbnail(app_config: object, request_json: objec
 
 
 def verify_dataset_title_info(uuid: str, request_headers: object) -> object:
-    nexus_token = nexus_token_from_request_headers(request_headers)
+    groups_token = groups_token_from_request_headers(request_headers)
     dataset_helper = DatasetHelper()
-    return dataset_helper.verify_dataset_title_info(uuid, nexus_token)
+    return dataset_helper.verify_dataset_title_info(uuid, groups_token)
 

--- a/src/dataset_helper_object.py
+++ b/src/dataset_helper_object.py
@@ -50,8 +50,8 @@ class DatasetHelper:
 
         if _entity_api_url is None:
             config = load_flask_instance_config()
-            _entity_api_url = config['ENTITY_WEBSERVICE_URL']
-            _search_api_url = config['SEARCH_WEBSERVICE_URL']
+            _entity_api_url = config['ENTITY_WEBSERVICE_URL'].rstrip('/')
+            _search_api_url = config['SEARCH_WEBSERVICE_URL'].rstrip('/')
 
     def get_organ_types_dict(self) -> object:
         yaml_file_url = 'https://raw.githubusercontent.com/hubmapconsortium/search-api/master/src/search-schema/data/definitions/enums/organ_types.yaml'


### PR DESCRIPTION
Address the following error with AWS API Gateway:

```
[2022-01-24 21:33:05] DEBUG in app_manager: =======get_dataset_ingest_update_record=======
[2022-01-24 21:33:05] DEBUG in app_manager: {'status': 'QA', 'pipeline_message': 'the process ran', 'ingest_metadata': {}}
[2022-01-24 21:33:05] INFO in app_manager: No existing thumbnail file found for the dataset uuid 009b93fbbca9122390eea307a807a571
[2022-01-24 21:33:05] DEBUG in connectionpool: Starting new HTTPS connection (1): entity-api.dev.hubmapconsortium.org:443
[2022-01-24 21:33:05] DEBUG in connectionpool: https://entity-api.dev.hubmapconsortium.org:443 "PUT //entities/009b93fbbca9122390eea307a807a571 HTTP/1.1" 404 52
[2022-01-24 21:33:05] ERROR in app_manager: Error while updating the dataset status using EntityApi.put_entities() status code:404  message:{"message": "Unable to find the requested resource"}
[2022-01-24 21:33:05] ERROR in app_manager: Sent: {"ingest_metadata": {}, "pipeline_message": "the process ran", "status": "QA"}
[pid: 52|app: 0|req: 9/18] 74.111.172.61 () {46 vars in 783 bytes} [Mon Jan 24 21:33:05 2022] PUT /datasets/status => generated 52 bytes in 510 msecs (HTTP/1.1 404) 2 headers in 86 bytes (1 switches on core 0)
```

Apparently AWS API Gateway doesn't allow extra slash in URL.