### PR TITLE
Yuanzhou/url fix aws gateway

### DIFF
--- a/src/api/entity_api.py
+++ b/src/api/entity_api.py
@@ -7,49 +7,16 @@ from api.api import Api
 class EntityApi(Api):
 
     def __init__(self, user_token: str, api_url: str):
-        super().__init__(user_token, api_url.rstrip('/'))
+        super().__init__(user_token, api_url)
 
     def post_entities(self, dataset_uuid: str, json: object, extra_headers: dict = {}) -> object:
-        return super().request_post(f"/entities/{dataset_uuid}", json, extra_headers)
+        return super().request_post(f"entities/{dataset_uuid}", json, extra_headers)
 
     def put_entities(self, dataset_uuid: str, json: object, extra_headers: dict = {}) -> object:
-        return super().request_put(f"/entities/{dataset_uuid}", json, extra_headers)
+        return super().request_put(f"entities/{dataset_uuid}", json, extra_headers)
 
     def get_entities(self, dataset_uuid: str) -> object:
-        return super().request_get(f"/entities/{dataset_uuid}")
+        return super().request_get(f"entities/{dataset_uuid}")
 
     def get_ancestors(self, dataset_uuid: str) -> object:
-        return super().request_get(f"/ancestors/{dataset_uuid}")
-
-    # The following calls are not being used by ingest-api currently
-    # Uncomment when being used
-
-    # def get_entity_types(self, dataset_uuid: str) -> object:
-    #     return super().request_get(f"/entity-types/{dataset_uuid}")
-
-    # def get_descendants(self, dataset_uuid: str) -> object:
-    #     return super().request_get(f"/descendants/{dataset_uuid}")
-
-    # def get_parents(self, dataset_uuid: str) -> object:
-    #     return super().request_get(f"/parents/{dataset_uuid}")
-
-    # def get_children(self, dataset_uuid: str) -> object:
-    #     return super().request_get(f"/children/{dataset_uuid}")
-
-    # def get_entities_provenance(self, dataset_uuid: str) -> object:
-    #     return super().request_get(f"/entities/{dataset_uuid}/provenance")
-
-    # def get_entities_ancestor_organs(self, dataset_uuid: str) -> object:
-    #     return super().request_get(f"/entities/{dataset_uuid}/ancestor-organs")
-
-    # def get_collections(self, dataset_uuid: str) -> object:
-    #     return super().request_get(f"/collections/{dataset_uuid}")
-
-    # def put_collections_add_datasets(self, collections_uuid: str, json) -> object:
-    #     return super().request_put(f"/collections{collections_uuid}/add-datasets", json)
-
-    # def get_doi_redirect(self, dataset_uuid: str) -> object:
-    #     return super().request_get(f"/doi/redirect/{dataset_uuid}")
-
-    # def get_entities_globus_url(self, dataset_uuid: str) -> object:
-    #     return super().request_get(f"/entities/{dataset_uuid}/globus-url")
+        return super().request_get(f"ancestors/{dataset_uuid}")

--- a/src/api/entity_api.py
+++ b/src/api/entity_api.py
@@ -7,7 +7,7 @@ from api.api import Api
 class EntityApi(Api):
 
     def __init__(self, user_token: str, api_url: str):
-        super().__init__(user_token, api_url)
+        super().__init__(user_token, api_url.rstrip('/'))
 
     def post_entities(self, dataset_uuid: str, json: object, extra_headers: dict = {}) -> object:
         return super().request_post(f"/entities/{dataset_uuid}", json, extra_headers)

--- a/src/api/search_api.py
+++ b/src/api/search_api.py
@@ -10,4 +10,4 @@ class SearchApi(Api):
         super().__init__(user_token, api_url)
 
     def get_assaytype(self, data_type: str) -> object:
-        return super().request_get_public(f"/assaytype/{data_type}")
+        return super().request_get_public(f"assaytype/{data_type}")

--- a/src/app.py
+++ b/src/app.py
@@ -865,7 +865,7 @@ def update_ingest_status():
         abort(400, jsonify( { 'error': 'no data found cannot process update' } ))
     
     try:
-        entity_api = EntityApi(app_manager.nexus_token_from_request_headers(request.headers),
+        entity_api = EntityApi(app_manager.groups_token_from_request_headers(request.headers),
                                commons_file_helper.removeTrailingSlashURL(app.config['ENTITY_WEBSERVICE_URL']))
 
         return app_manager.update_ingest_status_title_thumbnail(app.config, 

--- a/src/app_manager.py
+++ b/src/app_manager.py
@@ -16,17 +16,16 @@ logger = logging.getLogger(__name__)
 requests.packages.urllib3.disable_warnings(category = InsecureRequestWarning)
 
 
-def nexus_token_from_request_headers(request_headers: object) -> str:
+def groups_token_from_request_headers(request_headers: object) -> str:
     bearer_token = request_headers['AUTHORIZATION'].strip()
-    nexus_token = bearer_token[len('bearer '):].strip()
-    return nexus_token
+    groups_token = bearer_token[len('bearer '):].strip()
+    return groups_token
 
 
 def update_ingest_status_title_thumbnail(app_config: object, request_json: object, 
                                          request_headers: object, entity_api: EntityApi, 
                                          file_upload_helper_instance: UploadFileHelper) -> object:
     dataset_uuid = request_json['dataset_id'].strip()
-    nexus_token = nexus_token_from_request_headers(request_headers)
     dataset = Dataset(app_config)
     dataset_helper = DatasetHelper()
 
@@ -102,7 +101,7 @@ def update_ingest_status_title_thumbnail(app_config: object, request_json: objec
 
 
 def verify_dataset_title_info(uuid: str, request_headers: object) -> object:
-    nexus_token = nexus_token_from_request_headers(request_headers)
+    groups_token = groups_token_from_request_headers(request_headers)
     dataset_helper = DatasetHelper()
-    return dataset_helper.verify_dataset_title_info(uuid, nexus_token)
+    return dataset_helper.verify_dataset_title_info(uuid, groups_token)
 

--- a/src/dataset_helper_object.py
+++ b/src/dataset_helper_object.py
@@ -50,8 +50,8 @@ class DatasetHelper:
 
         if _entity_api_url is None:
             config = load_flask_instance_config()
-            _entity_api_url = config['ENTITY_WEBSERVICE_URL']
-            _search_api_url = config['SEARCH_WEBSERVICE_URL']
+            _entity_api_url = config['ENTITY_WEBSERVICE_URL'].rstrip('/')
+            _search_api_url = config['SEARCH_WEBSERVICE_URL'].rstrip('/')
 
     def get_organ_types_dict(self) -> object:
         yaml_file_url = 'https://raw.githubusercontent.com/hubmapconsortium/search-api/master/src/search-schema/data/definitions/enums/organ_types.yaml'

--- a/src/dataset_helper_object.py
+++ b/src/dataset_helper_object.py
@@ -50,8 +50,8 @@ class DatasetHelper:
 
         if _entity_api_url is None:
             config = load_flask_instance_config()
-            _entity_api_url = config['ENTITY_WEBSERVICE_URL'].rstrip('/')
-            _search_api_url = config['SEARCH_WEBSERVICE_URL'].rstrip('/')
+            _entity_api_url = config['ENTITY_WEBSERVICE_URL']
+            _search_api_url = config['SEARCH_WEBSERVICE_URL']
 
     def get_organ_types_dict(self) -> object:
         yaml_file_url = 'https://raw.githubusercontent.com/hubmapconsortium/search-api/master/src/search-schema/data/definitions/enums/organ_types.yaml'

--- a/test/api/test_entity_api.py
+++ b/test/api/test_entity_api.py
@@ -24,7 +24,7 @@ class TestEntityApi(unittest.TestCase):
 
         mock_request_post.assert_called()
         args = mock_request_post.call_args_list[0]
-        self.assertEqual(args[0][0], f"/entities/{dataset_uuid}")
+        self.assertEqual(args[0][0], f"entities/{dataset_uuid}")
         self.assertEqual(args[0][1], json)
         self.assertEqual(args[0][2], {})
 
@@ -37,7 +37,7 @@ class TestEntityApi(unittest.TestCase):
 
         mock_request_post.assert_called()
         args = mock_request_post.call_args_list[0]
-        self.assertEqual(args[0][0], f"/entities/{dataset_uuid}")
+        self.assertEqual(args[0][0], f"entities/{dataset_uuid}")
         self.assertEqual(args[0][1], json)
         self.assertEqual(args[0][2], {'extra_header': 'fun Header'})
 
@@ -50,7 +50,7 @@ class TestEntityApi(unittest.TestCase):
 
         mock_request_put.assert_called()
         args = mock_request_put.call_args_list[0]
-        self.assertEqual(args[0][0], f"/entities/{dataset_uuid}")
+        self.assertEqual(args[0][0], f"entities/{dataset_uuid}")
         self.assertEqual(args[0][1], json)
         self.assertEqual(args[0][2], {})
 
@@ -63,7 +63,7 @@ class TestEntityApi(unittest.TestCase):
 
         mock_request_put.assert_called()
         args = mock_request_put.call_args_list[0]
-        self.assertEqual(args[0][0], f"/entities/{dataset_uuid}")
+        self.assertEqual(args[0][0], f"entities/{dataset_uuid}")
         self.assertEqual(args[0][1], json)
         self.assertEqual(args[0][2], {'extra_header': 'fun Header'})
 
@@ -75,7 +75,7 @@ class TestEntityApi(unittest.TestCase):
 
         mock_request_get.assert_called()
         args = mock_request_get.call_args_list[0]
-        self.assertEqual(args[0][0], f"/entities/{dataset_uuid}")
+        self.assertEqual(args[0][0], f"entities/{dataset_uuid}")
 
     @patch('api.api.Api.request_get')
     def test_get_ancestors(self, mock_request_get):
@@ -85,4 +85,4 @@ class TestEntityApi(unittest.TestCase):
 
         mock_request_get.assert_called()
         args = mock_request_get.call_args_list[0]
-        self.assertEqual(args[0][0], f"/ancestors/{dataset_uuid}")
+        self.assertEqual(args[0][0], f"ancestors/{dataset_uuid}")

--- a/test/api/test_search_api.py
+++ b/test/api/test_search_api.py
@@ -23,4 +23,4 @@ class TestSearchApi(unittest.TestCase):
 
         mock_request_get_public.assert_called()
         args = mock_request_get_public.call_args_list[0]
-        self.assertEqual(args[0][0], f"/assaytype/{data_type}")
+        self.assertEqual(args[0][0], f"assaytype/{data_type}")

--- a/test/app_manager/test_app_manager.py
+++ b/test/app_manager/test_app_manager.py
@@ -15,8 +15,8 @@ class TestAppManager(unittest.TestCase):
         self.token = 'token'
         self.request_headers = {'AUTHORIZATION': f'bearer   {self.token}'}
 
-    def test_nexus_token_from_request_headers(self):
-        result = app_manager.nexus_token_from_request_headers(self.request_headers)
+    def test_groups_token_from_request_headers(self):
+        result = app_manager.groups_token_from_request_headers(self.request_headers)
 
         self.assertEqual(result, self.token)
 


### PR DESCRIPTION
Remove extra slash in API call. This extra slash is causing AWS API Gateway to throw 404 error.

```
[2022-01-24 21:33:05] DEBUG in app_manager: =======get_dataset_ingest_update_record=======
[2022-01-24 21:33:05] DEBUG in app_manager: {'status': 'QA', 'pipeline_message': 'the process ran', 'ingest_metadata': {}}
[2022-01-24 21:33:05] INFO in app_manager: No existing thumbnail file found for the dataset uuid 009b93fbbca9122390eea307a807a571
[2022-01-24 21:33:05] DEBUG in connectionpool: Starting new HTTPS connection (1): entity-api.dev.hubmapconsortium.org:443
[2022-01-24 21:33:05] DEBUG in connectionpool: https://entity-api.dev.hubmapconsortium.org:443 "PUT //entities/009b93fbbca9122390eea307a807a571 HTTP/1.1" 404 52
[2022-01-24 21:33:05] ERROR in app_manager: Error while updating the dataset status using EntityApi.put_entities() status code:404  message:{"message": "Unable to find the requested resource"}
[2022-01-24 21:33:05] ERROR in app_manager: Sent: {"ingest_metadata": {}, "pipeline_message": "the process ran", "status": "QA"}
[pid: 52|app: 0|req: 9/18] 74.111.172.61 () {46 vars in 783 bytes} [Mon Jan 24 21:33:05 2022] PUT /datasets/status => generated 52 bytes in 510 msecs (HTTP/1.1 404) 2 headers in 86 bytes (1 switches on core 0)
```

Apparently AWS API Gateway doesn't allow extra slash in URL even though it's valid (but not welcome) in general.