### PR TITLE
Return 404 on assets dir

### DIFF
--- a/docker/ingest-api-dev/nginx/conf.d/zssets.conf
+++ b/docker/ingest-api-dev/nginx/conf.d/zssets.conf
@@ -97,6 +97,13 @@ server {
         auth_request /file_auth;
 
         # Once authenticated/authorized, allow file access
+        # Requested by the portal-ui team, return 404 for both with slash and non-slash on a directory - 2/15/2022
+        # By default, Nginx does a 301 redirect if the requested directory has no trailing slash
+        # it retuns 403 if the requested directory has the trailing slash (due to direcotry index listing not enabled)
+        if (-d $document_root/$document_uri) {
+            return 404;
+        }
+        
         sendfile on;
         sendfile_max_chunk 2m;
         tcp_nopush on;

--- a/docker/ingest-api-prod/nginx/conf.d/zssets.conf
+++ b/docker/ingest-api-prod/nginx/conf.d/zssets.conf
@@ -97,6 +97,13 @@ server {
         auth_request /file_auth;
 
         # Once authenticated/authorized, allow file access
+        # Requested by the portal-ui team, return 404 for both with slash and non-slash on a directory - 2/15/2022
+        # By default, Nginx does a 301 redirect if the requested directory has no trailing slash
+        # it retuns 403 if the requested directory has the trailing slash (due to direcotry index listing not enabled)
+        if (-d $document_root/$document_uri) {
+            return 404;
+        }
+        
         sendfile on;
         sendfile_max_chunk 2m;
         tcp_nopush on;

--- a/docker/ingest-api-stage/nginx/conf.d/zssets.conf
+++ b/docker/ingest-api-stage/nginx/conf.d/zssets.conf
@@ -97,6 +97,13 @@ server {
         auth_request /file_auth;
 
         # Once authenticated/authorized, allow file access
+        # Requested by the portal-ui team, return 404 for both with slash and non-slash on a directory - 2/15/2022
+        # By default, Nginx does a 301 redirect if the requested directory has no trailing slash
+        # it retuns 403 if the requested directory has the trailing slash (due to direcotry index listing not enabled)
+        if (-d $document_root/$document_uri) {
+            return 404;
+        }
+        
         sendfile on;
         sendfile_max_chunk 2m;
         tcp_nopush on;

--- a/docker/ingest-api-test/nginx/conf.d/zssets.conf
+++ b/docker/ingest-api-test/nginx/conf.d/zssets.conf
@@ -97,6 +97,13 @@ server {
         auth_request /file_auth;
 
         # Once authenticated/authorized, allow file access
+        # Requested by the portal-ui team, return 404 for both with slash and non-slash on a directory - 2/15/2022
+        # By default, Nginx does a 301 redirect if the requested directory has no trailing slash
+        # it retuns 403 if the requested directory has the trailing slash (due to direcotry index listing not enabled)
+        if (-d $document_root/$document_uri) {
+            return 404;
+        }
+        
         sendfile on;
         sendfile_max_chunk 2m;
         tcp_nopush on;


### PR DESCRIPTION
Requested by the portal-ui team especially for handling zarr files. 

404 gets returned for both with slash and non-slash on a directory when requested directly in URL.

This still returns the actual file if found or 404 not found.