### PR TITLE
Correct doi_url value

### DIFF
--- a/src/datacite_doi_helper_object.py
+++ b/src/datacite_doi_helper_object.py
@@ -214,10 +214,9 @@ class DataCiteDoiHelper:
 
                 # Then update the dataset DOI properties via entity-api after the DOI gets published
                 try:
-                    doi_url = doi_data['data']['attributes']['url']
                     doi_name = datacite_api.build_doi_name(dataset['hubmap_id'])
                     entity_api = EntityApi(user_token, self.entity_api_url)
-                    updated_dataset = self.update_dataset_after_doi_published(dataset['uuid'], doi_name, doi_url, entity_api)
+                    updated_dataset = self.update_dataset_after_doi_published(dataset['uuid'], doi_name, entity_api)
 
                     return updated_dataset
                 except requests.exceptions.RequestException as e:
@@ -243,8 +242,6 @@ class DataCiteDoiHelper:
         The dataset uuid
     doi_name: str
         The registered doi: prefix/suffix
-    doi_url: str
-        The registered doi_url
     entity_api
         The EntityApi object instance
     
@@ -253,7 +250,7 @@ class DataCiteDoiHelper:
     dict
         The entity dict with updated DOI properties
     """
-    def update_dataset_after_doi_published(self, dataset_uuid: str, doi_name: str, doi_url: str, entity_api: EntityApi) -> object:
+    def update_dataset_after_doi_published(self, dataset_uuid: str, doi_name: str, entity_api: EntityApi) -> object:
 
         # Update the registered_doi, and doi_url properties after DOI made findable
         # Changing Dataset.status to "Published" and setting the published_* properties
@@ -261,7 +258,7 @@ class DataCiteDoiHelper:
         # See https://github.com/hubmapconsortium/ingest-ui/issues/354
         dataset_properties_to_update = {
             'registered_doi': doi_name,
-            'doi_url': doi_url
+            'doi_url': f'https://doi.org/{doi_name}'
         }
         response = entity_api.put_entities(dataset_uuid, dataset_properties_to_update)
 


### PR DESCRIPTION
We use `https://entity.api.hubmapconsortium.org/doi/redirect/<uuid>` as the landing page when registering a new DOI with DataCite. After a Findable DOI gets registered, should use `https://doi.org/<doi>` to set the entity `doi_url` value via entity-api in neo4j.