### PR TITLE
Implemented validation to make sure a dataset is ok to publish. Valid…

### DIFF
--- a/src/datacite_doi_helper_object.py
+++ b/src/datacite_doi_helper_object.py
@@ -145,11 +145,12 @@ class DataCiteDoiHelper:
     dict
         The registered DOI details
     """
-    def create_dataset_draft_doi(self, dataset: dict) -> object:
+    def create_dataset_draft_doi(self, dataset: dict, check_publication_status=True) -> object:
         if ('entity_type' in dataset) and (dataset['entity_type'] == 'Dataset'):
             # In case the given dataset is not published
-            if dataset['status'].lower() != 'published':
-                raise ValueError('This Dataset is not Published, can not register DOI')
+            if check_publication_status:
+                if dataset['status'].lower() != 'published':
+                    raise ValueError('This Dataset is not Published, can not register DOI')
 
             datacite_api = DataCiteApi(self.datacite_repository_id, self.datacite_repository_password,
                                        self.datacite_hubmap_prefix, self.datacite_api_url, self.entity_api_url)

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -10,6 +10,7 @@ Jinja2==3.0.3
 Flask==1.1.2
 flask_cors==3.0.10
 globus_sdk==2.0.1
+hubmap-sdk==1.0.1
 jsonref==0.2
 jsonschema==3.2.0
 neo4j==4.2.1


### PR DESCRIPTION
Implemented validation to make sure a dataset is ok to publish. Validation
now checks that the ancestor donor both contains metadata field, and that
the metadata field has either organ_donor_data, or living_donor_data, but
not both, and not neither. Also verifies that the dataset has contact
info and contributor info, and that they aren't empty. Beyond that, any 
validation on the contacts is performed by the datacite api.

Now calls the datacite helper to create the draft doi and publish the doi. 

Added to requirements.txt hubmap-sdk, which is used to do a
get_entity_by_id call.