### PR TITLE
Store relative path in database, log errors from uuid-api

### DIFF
--- a/src/file_upload_helper.py
+++ b/src/file_upload_helper.py
@@ -127,7 +127,8 @@ class UploadFileHelper:
         data['file_info'] = [file_info]
         response = requests.post(self.uuid_api_url, json = data, headers = headers, verify = False)
         if response is None or response.status_code != 200:
-            raise Exception(f"Unable to generate uuid for file {file_temp_dir}{temp_file_name}")
+            logger.error(f"POSTed request for file {file_temp_dir}{temp_file_name} returned response.status_code={response.status_code}, response.text = {response.text}.")
+            raise Exception(f"Unable to generate uuid for file {file_temp_dir}{temp_file_name}. See logs.")
         
         rsjs = response.json()
         file_uuid = rsjs[0]['uuid']


### PR DESCRIPTION
Changes to store relative path in database files.PATH column when files.BASE_DIR is INGEST_PORTAL_UPLOAD. Also, added logging of uuid-api error returned to ingest-api. Issue ingest-api#223.

Accompanying PR in uuid-api.