### PR TITLE
Revert "Install refactored commons branch"

### DIFF
--- a/docker/docker-compose.development.yml
+++ b/docker/docker-compose.development.yml
@@ -8,9 +8,9 @@ services:
       # Uncomment if tesitng against a specific branch of commons other than the PyPI package
       # Will also need to use the 'git+https://github.com/hubmapconsortium/commons.git@${COMMONS_BRANCH}#egg=hubmap-commons'
       # in src/requirements.txt accordingly
-      args:
-        # The commons github branch to be used during image build (default to main if not set or null)
-        - COMMONS_BRANCH=${COMMONS_BRANCH:-main}
+      # args:
+      #   # The commons github branch to be used during image build (default to main if not set or null)
+      #   - COMMONS_BRANCH=${COMMONS_BRANCH:-main}
     # Build the image with name and tag
     # Exit with an error message containing err if unset or empty in the environment
     image: hubmap/ingest-api:${INGEST_API_VERSION:?err}

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -14,8 +14,8 @@ requests==2.25.1
 # Use the published package from PyPI as default
 # Use the branch name of commons from github for testing new changes made in commons from different branch
 # Default is main branch specified in docker-compose.development.yml if not set
-git+https://github.com/hubmapconsortium/commons.git@shirey/refactor-mult-apps#egg=hubmap-commons
-#hubmap-commons==2.0.15
+# git+https://github.com/hubmapconsortium/commons.git@${COMMONS_BRANCH}#egg=hubmap-commons
+hubmap-commons==2.0.15
 
 # For parsing the secondary analysis files...
 anndata >= 0.7.8


### PR DESCRIPTION
Reverts hubmapconsortium/ingest-api#239

Not really code changes, but a branch used for testing against the refactored commons branch along with all other APIs on DEV

Being tested on DEV via PR #239, will use this revert PR to revert the changes once done testing.

Will also need to make a commons release and rebuild for TEST and PROD release.