### PR TITLE
Fixed inaccurate error message. If rui_location is NOT

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1714,7 +1714,7 @@ def validate_samples(headers, records, header):
                             f"Row Number: {rownum}. If sample type is not organ, source_id must point to a sample")
                     if rui_is_blank is False and source_dict['type'].lower() == 'donor':
                         file_is_valid = False
-                        error_msg.append(f"Row Number: {rownum}. If rui_location is blank, source_id cannot be a donor")
+                        error_msg.append(f"Row Number: {rownum}. If rui_location is not blank, source_id cannot be a donor")
 
 
     if file_is_valid:


### PR DESCRIPTION
blank (rui_location is provided) source id must not be a donor. Previous text said if rui_location IS blank.