### PR TITLE
Rename notification endpoint and add option to send email

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -18,7 +18,7 @@ from queue import Queue
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 import argparse
 from pathlib import Path
-from flask import Flask, g, jsonify, abort, request, json, Response, render_template
+from flask import Flask, g, jsonify, abort, request, json, Response
 from flask_cors import CORS
 from flask_mail import Mail, Message
 

--- a/src/instance/app.cfg.example
+++ b/src/instance/app.cfg.example
@@ -6,6 +6,18 @@ ENABLE_CORS = False
 SLACK_DEFAULT_CHANNEL = ''
 SLACK_CHANNEL_TOKEN = ''
 
+# Email settings for Flask-Mail extension
+MAIL_SERVER = ''
+MAIL_PORT = 587
+MAIL_USE_TLS = True
+MAIL_USERNAME = ''
+MAIL_PASSWORD = '' # This is the token for authentication, not the account password
+MAIL_DEFAULT_SENDER = ('name', 'email address')
+MAIL_DEBUG = False
+# Admin emails, not part of Flask-Mail configuration
+MAIL_ADMIN_LIST = ['recipient #1']
+MAIL_SUBJECT_LINE = 'Copy of Slack message on channel {channel} at {sent_dt}'
+
 # Neo4j connection
 NEO4J_SERVER = ''
 NEO4J_USERNAME = ''

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,6 @@
 Flask==2.1.3
 flask_cors==3.0.10
+flask-mail==0.9.1
 globus_sdk==2.0.1
 
 hubmap-sdk==1.0.3


### PR DESCRIPTION
Initial commit for ingest-api issue #328.  Rename the notification endpoint to /notify, and add an option to email a message once it posts to Slack.