### PR TITLE
Update workspaces-passthrough.conf

### DIFF
--- a/docker/ingest-api/nginx/conf.d-prod/workspaces-passthrough.conf
+++ b/docker/ingest-api/nginx/conf.d-prod/workspaces-passthrough.conf
@@ -25,6 +25,8 @@ server {
     access_log /usr/src/app/log/nginx_access_workspaces-passthrough.log;
     error_log /usr/src/app/log/nginx_error_workspaces-passthrough.log warn;
 
+    client_max_body_size 100M;
+
     location / {
         # Forward request to workspaces-server running on the host port 5050
         proxy_pass http://172.17.0.1:5050;


### PR DESCRIPTION
This PR sets the client max body size to 100MB instead of the Nginx default 1MB.