### PR TITLE
Fixed the get globus url function. For public, it

### DIFF
--- a/src/instance/app.cfg.example
+++ b/src/instance/app.cfg.example
@@ -61,7 +61,7 @@ GLOBUS_PROTECTED_ENDPOINT_UUID = 'bdaf8547-aab3-4142-97bd-0a16d5cd9f58'
 # Sub directories under the base data/globus directory where different access levels of data sits
 PROTECTED_DATA_SUBDIR = 'private'
 CONSORTIUM_DATA_SUBDIR = 'consortium'
-PUBLIC_DATA_SUBDIR = 'public'
+PUBLIC_DATA_SUBDIR = ''
 
 # Absolute file paths of the Globus endpoints (shown for DEV, change for TEST/PROD deployment)
 GLOBUS_PUBLIC_ENDPOINT_FILEPATH = '/hive/hubmap-dev/data/public'


### PR DESCRIPTION
Fixed the get globus url function. For public, it 
incorrectly added a space, and included `public` where
it should have been blank. 2 additional slashes were
also included. To accompany this change, app.cfg.example
has also been updated. The config file on dev/prod will
need to reflect this change.

Additionally, the check files_exist used to determine has_data has been updated to include group name in the path when checking consortium and protected datasets. 