### PR TITLE
Removed relative globus endpoint filepath entry from

### DIFF
--- a/src/ingest_file_helper.py
+++ b/src/ingest_file_helper.py
@@ -84,13 +84,13 @@ class IngestFileHelper:
         grp_name = AuthHelper.getGroupDisplayName(group_uuid)
         if access_level == 'protected':
             endpoint_id = self.appconfig['GLOBUS_PROTECTED_ENDPOINT_UUID']
-            rel_path = str(os.path.join(self.appconfig['RELATIVE_GLOBUS_PROTECTED_ENDPOINT_FILEPATH'], grp_name, dataset_uuid))
+            rel_path = file_helper.ensureBeginningSlashURL(str(os.path.join(self.appconfig['PROTECTED_DATA_SUBDIR'], grp_name, dataset_uuid)))
         elif published:
             endpoint_id = self.appconfig['GLOBUS_PUBLIC_ENDPOINT_UUID']
-            rel_path = str(os.path.join(self.appconfig['RELATIVE_GLOBUS_PUBLIC_ENDPOINT_FILEPATH'], dataset_uuid))
+            rel_path = file_helper.ensureBeginningSlashURL(str(os.path.join(self.appconfig['PUBLIC_DATA_SUBDIR'], dataset_uuid)))
         else:
             endpoint_id = self.appconfig['GLOBUS_CONSORTIUM_ENDPOINT_UUID']
-            rel_path = str(os.path.join(self.appconfig['RELATIVE_GLOBUS_CONSORTIUM_ENDPOINT_FILEPATH'], grp_name, dataset_uuid))
+            rel_path = file_helper.ensureBeginningSlashURL(str(os.path.join(self.appconfig['CONSORTIUM_DATA_SUBDIR'], grp_name, dataset_uuid)))
 
         return {"rel_path":rel_path, "globus_endpoint_uuid":endpoint_id}
 

--- a/src/instance/app.cfg.example
+++ b/src/instance/app.cfg.example
@@ -59,7 +59,7 @@ GLOBUS_CONSORTIUM_ENDPOINT_UUID = '3cb7d673-a3db-40e9-8376-f2ead6cb5a45'
 GLOBUS_PROTECTED_ENDPOINT_UUID = 'bdaf8547-aab3-4142-97bd-0a16d5cd9f58'
 
 # Sub directories under the base data/globus directory where different access levels of data sits
-PROTECTED_DATA_SUBDIR = 'private'
+PROTECTED_DATA_SUBDIR = 'protected'
 CONSORTIUM_DATA_SUBDIR = 'consortium'
 PUBLIC_DATA_SUBDIR = ''
 
@@ -67,11 +67,6 @@ PUBLIC_DATA_SUBDIR = ''
 GLOBUS_PUBLIC_ENDPOINT_FILEPATH = '/hive/hubmap-dev/data/public'
 GLOBUS_CONSORTIUM_ENDPOINT_FILEPATH = '/hive/hubmap-dev/data/consortium'
 GLOBUS_PROTECTED_ENDPOINT_FILEPATH = '/hive/hubmap-dev/data/protected'
-
-# Relative file paths of the Globus endpoints
-RELATIVE_GLOBUS_PUBLIC_ENDPOINT_FILEPATH = '/'
-RELATIVE_GLOBUS_CONSORTIUM_ENDPOINT_FILEPATH = '/consortium'
-RELATIVE_GLOBUS_PROTECTED_ENDPOINT_FILEPATH = '/protected'
 
 # File Access Control List Settings to be used by `setfacl` command
 # Set value to `hubmap` for all the following users and groups on localhost docker mode


### PR DESCRIPTION
Removed relative globus endpoint filepath entry fromconfig file. Refactored ingest_file_helper.py to use 
DATA_SUBDIR instead. Fixed an error in protected datasubdir where it was 'private' instead of 'protected'. Modified app.cfg.example.