### PR TITLE
Modified regex patterns in sample bulk validation to

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -2062,8 +2062,8 @@ def validate_samples(headers, records, header):
 
             # validate sample_protocol
             protocol = data_row['sample_protocol']
-            selection_protocol_pattern1 = re.match('^https://dx\.doi\.org/[\d]+\.[\d]+/protocols\.io\.[\w]*$', protocol)
-            selection_protocol_pattern2 = re.match('^[\d]+\.[\d]+/protocols\.io\.[\w]*$', protocol)
+            selection_protocol_pattern1 = re.match('^https://dx\.doi\.org/[\d]+\.[\d]+/protocols\.io\.[\w/]*$', protocol)
+            selection_protocol_pattern2 = re.match('^[\d]+\.[\d]+/protocols\.io\.[\w/]*$', protocol)
             if selection_protocol_pattern2 is None and selection_protocol_pattern1 is None:
                 file_is_valid = False
                 error_msg.append(


### PR DESCRIPTION
Following merged PR #370 for TEST

accommodate for protocol url's ending with version
 numbers (e.g `/v1`) by allowing slashes following the
 period after "io".