### PR TITLE
validate_records_uuids: fixed headers in call to entity-api

### DIFF
--- a/src/routes/validation/__init__.py
+++ b/src/routes/validation/__init__.py
@@ -263,8 +263,8 @@ def validate_records_uuids(records: list, entity_type: str, sub_type, pathname: 
         auth_helper_instance: AuthHelper = AuthHelper.instance()
         token = auth_helper_instance.getAuthorizationTokens(request.headers)
         resp = requests.get(f'{entity_url}entities/{entity_id}',
-                            headers={f'Authorization: Bearer {token}',
-                                     'X-Application: ingest-api'})
+                            headers={'Authorization': f'Bearer {token}',
+                                     'X-Application': 'ingest-api'})
         if resp.status_code < 300:
             entity = resp.json()
             if sub_type is not None:


### PR DESCRIPTION
Fixed a but in validate_records_uuids() in __init__.py where the headers in the call to entity-api was broken.
This was found when Jes started to use the code.
