### PR TITLE
Bugfix Visum (no probes) rule

### DIFF
--- a/src/routes/assayclassifier/testing_rule_chain.json
+++ b/src/routes/assayclassifier/testing_rule_chain.json
@@ -716,7 +716,7 @@
     {
         "type": "match",
         "match": "not_dcwg and is_derived and data_types[0] in ['visium_no_probes']",
-        "value": "{'assaytype': 'visium-no-probes', 'vitessce-hints': [], 'primary': false, 'contains-pii': false, 'description': 'Visium (no probes) [Salmon + Scanpy]'}",
+        "value": "{'assaytype': 'visium-no-probes', 'vitessce-hints': [], 'primary': false, 'contains-pii': false, 'description': 'Visium (no probes) [Salmon + Scanpy]', 'is-multi-assay': true}",
         "rule_description": "non-DCWG derived visium-no-probes"
     }
 ]

--- a/src/routes/assayclassifier/testing_rule_chain.json
+++ b/src/routes/assayclassifier/testing_rule_chain.json
@@ -715,7 +715,7 @@
     },
     {
         "type": "match",
-        "match": "is_dcwg and is_derived and data_types[0] in ['visium_no_probes']",
+        "match": "not_dcwg and is_derived and data_types[0] in ['visium_no_probes']",
         "value": "{'assaytype': 'visium-no-probes', 'vitessce-hints': [], 'primary': false, 'contains-pii': false, 'description': 'Visium (no probes) [Salmon + Scanpy]'}",
         "rule_description": "non-DCWG derived visium-no-probes"
     }


### PR DESCRIPTION
Rule for derived datasets can't identify Visium as is_dcwg from the entity-api, updating the rule to treat it as non_dcwg in the meantime.