### PR TITLE
Rules: dataset type should be Cell DIVE not Cell Dive.

### DIFF
--- a/src/routes/assayclassifier/testing_rule_chain.json
+++ b/src/routes/assayclassifier/testing_rule_chain.json
@@ -62,7 +62,7 @@
     {
         "type": "match",
         "match": "not_dcwg and is_derived and data_types[0] in ['celldive_deepcell']",
-        "value": "{'assaytype': 'celldive_deepcell', 'vitessce-hints': ['sprm', 'anndata', 'is_image', 'is_tiled'], 'primary': false, 'contains-pii': false, 'description': 'CellDIVE [DeepCell + SPRM]'}",
+        "value": "{'assaytype': 'celldive_deepcell', 'vitessce-hints': ['sprm', 'anndata', 'is_image', 'is_tiled'], 'primary': false, 'contains-pii': false, 'description': 'Cell DIVE [DeepCell + SPRM]'}",
         "rule_description": "non-DCWG derived celldive_deepcell"
     },
     {

--- a/src/routes/assayclassifier/testing_rule_chain.json
+++ b/src/routes/assayclassifier/testing_rule_chain.json
@@ -56,7 +56,7 @@
     {
         "type": "match",
         "match": "not_dcwg and not_derived and assay_type in ['cell-dive', 'cell DIVE', 'Cell DIVE']",
-        "value": "{'assaytype': 'cell-dive', 'dir-schema': 'celldive-v0', 'tbl-schema': 'celldive-v'+version.to_str, 'vitessce-hints': [], 'contains-pii': false, 'primary': true, 'description': 'Cell DIVE', 'dataset-type': 'Cell Dive' }",
+        "value": "{'assaytype': 'cell-dive', 'dir-schema': 'celldive-v0', 'tbl-schema': 'celldive-v'+version.to_str, 'vitessce-hints': [], 'contains-pii': false, 'primary': true, 'description': 'Cell DIVE', 'dataset-type': 'Cell DIVE' }",
         "rule_description": "non-DCWG primary cell-dive"
     },
     {
@@ -637,8 +637,8 @@
     },
     {
         "type": "match",
-        "match": "is_dcwg and dataset_type == 'Cell Dive'",
-        "value": "{'assaytype': 'cell-dive', 'vitessce-hints': [], 'dir-schema': 'celldive-v2', 'contains-pii': false, 'primary': true, 'dataset-type': 'Cell Dive', 'description': 'Cell DIVE'}",
+        "match": "is_dcwg and dataset_type == 'Cell DIVE'",
+        "value": "{'assaytype': 'cell-dive', 'vitessce-hints': [], 'dir-schema': 'celldive-v2', 'contains-pii': false, 'primary': true, 'dataset-type': 'Cell DIVE', 'description': 'Cell DIVE'}",
         "rule_description": "DCWG cell-dive"
     },
     {


### PR DESCRIPTION
Following merged PR #517 #519 for TEST

Need to update Neo4j then reindex

```
//collect UUIDs first so we can reindex just these if needed
match (ds) where ds.dataset_type = 'Cell Dive' return ds.uuid;
match (ds) where ds.dataset_type = 'Cell Dive' set ds.dataset_type = "Cell DIVE";
match (ds) where ds.dataset_type = 'Cell Dive [DeepCell + SPRM]' return ds.uuid;
match (ds) where ds.dataset_type = 'Cell Dive [DeepCell + SPRM]' set ds.dataset_type = 'Cell DIVE [DeepCell + SPRM]';
```