### PR TITLE
Handle missing/bad Authorization header

### DIFF
--- a/ingest-api-spec.yaml
+++ b/ingest-api-spec.yaml
@@ -677,7 +677,7 @@ paths:
                   has_data_admin_privs:
                     type: boolean
         "401":
-          description: User's token is not valid
+          description: User's token is not valid or not specified
 
 servers:
   - url: "https://uuid.hubmapconsortium.org/dataingest"

--- a/src/routes/privs/__init__.py
+++ b/src/routes/privs/__init__.py
@@ -17,11 +17,7 @@ def privs_has_data_admin_privs():
     For a valid logged in token it will return the json {'has_data_admin_privs': true/false}
     with a status_code of 200.
     """
-    headers: dict = {
-        "Content-Type": "application/json"
-    }
     start_of_token: int = len('BEARER ')
-
     authorization: str = request.headers.get('authorization')
     if authorization is None or len(authorization) < start_of_token:
         return Response("Non-active login", 401)
@@ -31,4 +27,4 @@ def privs_has_data_admin_privs():
     data_admin_privs: List[dict] = auth_helper_instance.has_data_admin_privs(groups_token)
     if isinstance(data_admin_privs, Response):
         return data_admin_privs
-    return make_response(jsonify({"has_data_admin_privs": data_admin_privs}), 200, headers)
+    return jsonify({"has_data_admin_privs": data_admin_privs})

--- a/src/routes/privs/__init__.py
+++ b/src/routes/privs/__init__.py
@@ -11,18 +11,24 @@ logger = logging.getLogger(__name__)
 
 @privs_blueprint.route('/privs/has-data-admin')
 def privs_has_data_admin_privs():
-    groups_token: str = get_groups_token()
-    auth_helper_instance: AuthHelper = AuthHelper.instance()
-
-    data_admin_privs: List[dict] = auth_helper_instance.has_data_admin_privs(groups_token)
-    if isinstance(data_admin_privs, Response):
-        return data_admin_privs
-
+    """
+    The endpoint will return a status_code of 401 (as per the ingest-api-spec.yaml file)
+    if the "User's token is not valid" (missing, or not logged in).
+    For a valid logged in token it will return the json {'has_data_admin_privs': true/false}
+    with a status_code of 200.
+    """
     headers: dict = {
         "Content-Type": "application/json"
     }
+    start_of_token: int = len('BEARER ')
+
+    authorization: str = request.headers.get('authorization')
+    if authorization is None or len(authorization) < start_of_token:
+        return Response("Non-active login", 401)
+
+    groups_token: str = authorization[start_of_token:]
+    auth_helper_instance: AuthHelper = AuthHelper.instance()
+    data_admin_privs: List[dict] = auth_helper_instance.has_data_admin_privs(groups_token)
+    if isinstance(data_admin_privs, Response):
+        return data_admin_privs
     return make_response(jsonify({"has_data_admin_privs": data_admin_privs}), 200, headers)
-
-
-def get_groups_token() -> str:
-    return request.headers.get('authorization')[7:]

--- a/src/routes/privs/__init__.py
+++ b/src/routes/privs/__init__.py
@@ -17,14 +17,12 @@ def privs_has_data_admin_privs():
     For a valid logged in token it will return the json {'has_data_admin_privs': true/false}
     with a status_code of 200.
     """
-    start_of_token: int = len('BEARER ')
-    authorization: str = request.headers.get('authorization')
-    if authorization is None or len(authorization) < start_of_token:
-        return Response("Non-active login", 401)
+    authorization = request.headers.get('authorization')
+    if authorization is None:
+        return Response("Please specify an Authorization Header", 401)
 
-    groups_token: str = authorization[start_of_token:]
     auth_helper_instance: AuthHelper = AuthHelper.instance()
-    data_admin_privs: List[dict] = auth_helper_instance.has_data_admin_privs(groups_token)
+    data_admin_privs = auth_helper_instance.has_data_admin_privs(authorization[7:])
     if isinstance(data_admin_privs, Response):
         return data_admin_privs
     return jsonify({"has_data_admin_privs": data_admin_privs})


### PR DESCRIPTION
    The endpoint will return a status_code of 401 (as per the ingest-api-spec.yaml file)
    if the "User's token is not valid" (missing, or not logged in).
    For a valid logged in token it will return the json {'has_data_admin_privs': true/false}
    with a status_code of 200.