### PR TITLE
The creation of entity_dict is within the if statement where the DOI …

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1069,15 +1069,15 @@ def publish_datastage(identifier):
             auth_tokens = auth_helper.getAuthorizationTokens(request.headers)
             entity_instance = EntitySdk(token=auth_tokens, service_url=app.config['ENTITY_WEBSERVICE_URL'])
             doi_info = None
+
+            entity = entity_instance.get_entity_by_id(dataset_uuid)
+            entity_dict = vars(entity)
+
             # Generating DOI's for lab processed/derived data as well as IEC/pipeline/airflow processed/derived data).
             if is_primary or has_entity_lab_processed_data_type:
                 # DOI gets generated here
                 # Note: moved dataset title auto generation to entity-api - Zhou 9/29/2021
                 datacite_doi_helper = DataCiteDoiHelper()
-
-                entity = entity_instance.get_entity_by_id(dataset_uuid)
-                entity_dict = vars(entity)
-
                 try:
                     datacite_doi_helper.create_dataset_draft_doi(entity_dict, check_publication_status=False)
                 except Exception as e:


### PR DESCRIPTION
…is generated. Moved it out one level.

Issue: https://github.com/hubmapconsortium/ingest-api/issues/575

testing, I'm trying to publish central processed dataset 59e8b98ce6094e0b73c627edb5b00a09 on TEST- I'm seeing this error:

[2024-07-10 15:14:58] ERROR in app: local variable 'entity_dict' referenced before assignment
Traceback (most recent call last):
  File "/usr/src/app/src/./app.py", line 1130, in publish_datastage
    if is_primary or metadata_json_based_on_creation_action(entity_dict.get('creation_action')):
UnboundLocalError: local variable 'entity_dict' referenced before assignmen

The creation of entity_dict is within the if statement where the DOI is generated. Moved it out one level.

NOTE from Joe: please create a new PR, this time it can go to main directly since we already started the tests on TEST.
