### PR TITLE
Temp mitigation to ast parsing

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -2711,11 +2711,18 @@ def update_datasets_datastatus():
             if isinstance(dataset[prop], str) and \
                     len(dataset[prop]) >= 2 and \
                     dataset[prop][0] == "[" and dataset[prop][-1] == "]":
-                prop_as_list = string_helper.convert_str_literal(dataset[prop])
-                if len(prop_as_list) > 0:
-                    dataset[prop] = prop_as_list
-                else:
-                    dataset[prop] = ""
+                
+                # For cases like `"ingest_task": "[Empty directory]"` we should not
+                # convert to a list and will cause ValueError if we try to convert
+                # Leave it as the original value and move on - Zhou 7/22/2024
+                try:
+                    prop_as_list = string_helper.convert_str_literal(dataset[prop])
+                    if len(prop_as_list) > 0:
+                        dataset[prop] = prop_as_list
+                    else:
+                        dataset[prop] = ""
+                except ValueError:
+                    pass
             if dataset[prop] is None:
                 dataset[prop] = ""
             if prop == 'processed_datasets':


### PR DESCRIPTION
```
[2024-07-22 14:56:59] ERROR in app: Exception on /datasets/data-status [GET]
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/hubmap_commons/string_helper.py", line 96, in convert_str_literal
    data = ast.literal_eval(data_str)
  File "/usr/lib64/python3.9/ast.py", line 62, in literal_eval
    node_or_string = parse(node_or_string, mode='eval')
  File "/usr/lib64/python3.9/ast.py", line 50, in parse
    return compile(source, filename, mode, flags,
  File "<unknown>", line 1
    [Empty directory]
           ^
SyntaxError: invalid syntax

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 1473, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 882, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 880, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 865, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
  File "/usr/src/app/src/./app.py", line 1943, in dataset_data_status
    combined_results = update_datasets_datastatus()
  File "/usr/src/app/src/./app.py", line 2714, in update_datasets_datastatus
    prop_as_list = string_helper.convert_str_literal(dataset[prop])
  File "/usr/local/lib/python3.9/site-packages/hubmap_commons/string_helper.py", line 102, in convert_str_literal
    raise ValueError(f"Invalid expression (string value): {data_str} from ast.literal_eval(); "
ValueError: Invalid expression (string value): [Empty directory] from ast.literal_eval(); specific error: invalid syntax (<unknown>, line 1)
[pid: 120|app: 0|req: 17/31] 172.18.0.2 () {84 vars in 1421 bytes} [Mon Jul 22 14:56:40 2024] GET /datasets/data-status => generated 194 bytes in 19242 msecs (HTTP/1.0 500) 2 headers in 91 bytes (1 switches on core 0)
```