### PR TITLE
Derek furst/move ingest board data loading

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,4 +1,3 @@
-import sys
 import datetime
 import redis
 import glob

--- a/src/app.py
+++ b/src/app.py
@@ -1,3 +1,4 @@
+import sys
 import datetime
 import redis
 import glob
@@ -11,6 +12,7 @@ import json
 from uuid import UUID
 import yaml
 import csv
+import threading
 from typing import List
 import time
 from threading import Thread
@@ -2835,8 +2837,8 @@ scheduler.add_job(
     name="Update Upload Data Status Job"
 )
 
-update_datasets_datastatus()
-update_uploads_datastatus()
+threading.Thread(target=update_datasets_datastatus).start()
+threading.Thread(target=update_uploads_datastatus).start()
 
 # For local development/testing
 if __name__ == '__main__':


### PR DESCRIPTION
Initial generation of the data for the ingest board was blocking the flask app from starting. The subsequent scheduled hourly runs were just fine operating in the background, but the original runs were invoked manually (as the scheduler has no option to run at minute 0 and then hourly afterwards). The request was to move the manual first generation until after the flask app starts. The reason we cannot do this is because the flask app doesn't actually return until it stops so anything after the app.run never gets called. 

We fix the problem by simply making the initial calls run in the background just like the rest of them. In my local testing, the flask app seems to respond just fine during this initial generation 