### PR TITLE
Detect assayclassifier call for Sample, Donor

### DIFF
--- a/src/routes/assayclassifier/__init__.py
+++ b/src/routes/assayclassifier/__init__.py
@@ -127,6 +127,9 @@ def build_entity_metadata(entity) -> dict:
         metadata["data_types"] = calculate_data_types(entity)
 
     metadata["entity_type"] = entity.entity_type
+    if metadata["entity_type"].upper() in ["DONOR", "SAMPLE"]:
+        raise ValueError(f"Entity is a {metadata['entity_type']}")
+    logger.info(f"Entity type is {metadata['entity_type']}")
     metadata["dag_provenance_list"] = dag_prov_list
     metadata["creation_action"] = entity.creation_action
 
@@ -159,6 +162,9 @@ def get_ds_assaytype(ds_uuid: str):
             apply_source_type_transformations(source_type, rule_value_set)
 
         return jsonify(rule_value_set)
+    except ValueError as excp:
+        logger.error(excp, exc_info=True)
+        return Response("Bad parameter: {excp}", 400)
     except ResponseException as re:
         logger.error(re, exc_info=True)
         return re.response
@@ -186,6 +192,9 @@ def get_ds_rule_metadata(ds_uuid: str):
         entity = get_entity(ds_uuid)
         metadata = build_entity_metadata(entity)
         return jsonify(metadata)
+    except ValueError as excp:
+        logger.error(excp, exc_info=True)
+        return Response("Bad parameter: {excp}", 400)
     except ResponseException as re:
         logger.error(re, exc_info=True)
         return re.response


### PR DESCRIPTION
Previously, calls to the assaytype or assaytype/metadata endpoints with uuids/HuBMAP IDs for samples or donors were not properly flagged and would cause a 500 return.  This mod catches those cases and returns a 400 User Error instead.