### PR TITLE
Bug Fix - None Values

### DIFF
--- a/src/routes/assayclassifier/__init__.py
+++ b/src/routes/assayclassifier/__init__.py
@@ -201,7 +201,8 @@ def standardize_results(rule_chain_json: dict, ubkg_json: dict) -> dict:
     for pre_integration_key in pre_integration_keys:
         ubkg_key = pre_integration_to_ubkg_translation.get(pre_integration_key, pre_integration_key)
         ubkg_value = ubkg_json.get(ubkg_key)
-        ubkg_transformed_json[pre_integration_key] = ubkg_value
+        if ubkg_value is not None:
+            ubkg_transformed_json[pre_integration_key] = ubkg_value
 
     return rule_chain_json | ubkg_transformed_json
 


### PR DESCRIPTION
Because all fields are always available for value sets in UBKG, we need to omit those fields that have None type values from our response, as this is how it previously functioned.