### PR TITLE
Welling/assay rules pre post

### DIFF
--- a/src/routes/assayclassifier/__init__.py
+++ b/src/routes/assayclassifier/__init__.py
@@ -23,69 +23,60 @@ from .rule_chain import (
     RuleLogicException,
 )
 
+from .source_is_human import source_is_human
+
 bp = Blueprint("assayclassifier", __name__)
 
 logger: logging.Logger = logging.getLogger(__name__)
 
+pre_rule_chain = None
+body_rule_chain = None
+post_rule_chain = None
 
-rule_chain = None
 
-# Have to translate pre-UBKG keys to UBKG keys
-# Format is:
-# "Key before UBKG integration": "UBKG Key"
-pre_integration_to_ubkg_translation = {
-    'vitessce-hints': 'vitessce_hints',
-    'dir-schema': 'dir_schema',
-    'tbl-schema': 'tbl_schema',
-    'contains-pii': 'contains_full_genetic_sequences',
-    'dataset-type': 'dataset_type',
-    'is-multi-assay': 'is_multiassay',
-    'pipeline-shorthand': 'pipeline_shorthand',
-    'must-contain': 'must_contain',
-}
-
-# These are the keys returned by the rule chain before UBKG integration.
-# We will return the UBKG data in this format as well for MVP.
-# This is to avoid too much churn on end-users.
-# We set primary manually so ignore it.
-pre_integration_keys = [
-    'assaytype',
-    'vitessce-hints',
-    'dir-schema',
-    'tbl-schema',
-    'contains-pii',
-    #'primary',
-    'dataset-type',
-    'description',
-    'is-multi-assay',
-    'pipeline-shorthand',
-    'must-contain',
-    "process_state"
-]
-
-def initialize_rule_chain():
-    global rule_chain
+def initialize_rule_chains():
+    global pre_rule_chain, body_rule_chain, post_rule_chain
     rule_src_uri = current_app.config["RULE_CHAIN_URI"]
     try:
-        json_rules = urllib.request.urlopen(rule_src_uri)
+        rule_json = urllib.request.urlopen(rule_src_uri)
     except json.decoder.JSONDecodeError as excp:
         raise RuleSyntaxException(excp) from excp
-    rule_chain = RuleLoader(json_rules).load()
-    print("RULE CHAIN FOLLOWS")
-    rule_chain.dump(stdout)
-    print("RULE CHAIN ABOVE")
+    rule_chain_dict = RuleLoader(rule_json).load()
+    pre_rule_chain = rule_chain_dict["pre"]
+    body_rule_chain = rule_chain_dict["body"]
+    post_rule_chain = rule_chain_dict["post"]
 
 
-def calculate_assay_info(metadata: dict) -> dict:
-    if not rule_chain:
-        initialize_rule_chain()
+def calculate_assay_info(metadata: dict,
+                         source_is_human: bool,
+                         lookup_ubkg: Callable[[str], dict]
+                         ) -> dict:
+    if any(elt is None
+           for elt in [pre_rule_chain, body_rule_chain, post_rule_chain]):
+        initialize_rule_chains()
     for key, value in metadata.items():
         if type(value) is str:
             if value.isdigit():
                 metadata[key] = int(value)
-    rslt = rule_chain.apply(metadata)
-    # TODO: check that rslt has the expected parts
-    return rslt
+    try:
+        pre_values = pre_rule_chain.apply(metadata)
+        body_values = body_rule_chain.apply(metadata, ctx=pre_values)
+        assert "ubkg_code" in body_values, ("Rule matched but lacked ubkg_code:"
+                                            f" {body_values}")
+        ubkg_values = lookup_ubkg(body_values.get("ubkg_code", "NO_CODE")).get("value", {})
+        rslt = post_rule_chain.apply(
+            {},
+            ctx={
+                "source_is_human": source_is_human,
+                "values": body_values,
+                "ubkg_values": ubkg_values,
+                "pre_values": pre_values,
+                # "DEBUG": True
+            }
+        )
+        return rslt
+    except NoMatchException:
+        return {}
 
 
 def calculate_data_types(entity: dict) -> list[str]:
@@ -169,15 +160,6 @@ def build_entity_metadata(entity) -> dict:
     return metadata
 
 
-def apply_source_type_transformations(source_type: str, rule_value_set: dict) -> dict:
-    # If we get more complicated transformations we should consider refactoring.
-    # For now, this should suffice.
-    if source_type.upper() == "MOUSE":
-        rule_value_set["contains-pii"] = False
-
-    return rule_value_set
-
-
 def get_data_from_ubkg(ubkg_code: str) -> dict:
     query = urllib.parse.urlencode({"application_context": current_app.config['APPLICATION_CONTEXT']})
     ubkg_api_url = f"{current_app.config['UBKG_INTEGRATION_ENDPOINT']}assayclasses/{ubkg_code}?{query}"
@@ -192,41 +174,20 @@ def get_data_from_ubkg(ubkg_code: str) -> dict:
     return json.loads(response_data)
 
 
-def standardize_results(rule_chain_json: dict, ubkg_json: dict) -> dict:
-    # Initialize this with conditional logic to set 'primary' true or false.
-    ubkg_transformed_json = {
-        "primary": ubkg_json.get("process_state") == "primary"
-    }
-
-    for pre_integration_key in pre_integration_keys:
-        ubkg_key = pre_integration_to_ubkg_translation.get(pre_integration_key, pre_integration_key)
-        ubkg_value = ubkg_json.get(ubkg_key)
-        if ubkg_value is not None:
-            ubkg_transformed_json[pre_integration_key] = ubkg_value
-
-    return rule_chain_json | ubkg_transformed_json
-
-
 @bp.route("/assaytype/<ds_uuid>", methods=["GET"])
 def get_ds_assaytype(ds_uuid: str):
     try:
         entity = get_entity(ds_uuid)
         metadata = build_entity_metadata(entity)
-        rules_json = calculate_assay_info(metadata)
-
-        if hasattr(entity, "sources") and isinstance(entity.sources, list):
-            source_type = ""
-            for source in entity.sources:
-                if source_type := source.get("source_type"):
-                    # If there is a single Human source_type, treat this as a Human case
-                    if source_type.upper() == "HUMAN":
-                        break
-            apply_source_type_transformations(source_type, rules_json)
-
-        ubkg_value_json = get_data_from_ubkg(rules_json.get("ubkg_code")).get("value", {})
-        merged_json = standardize_results(rules_json, ubkg_value_json)
-        merged_json["ubkg_json"] = ubkg_value_json
-        return jsonify(merged_json)
+        is_human = source_is_human([ds_uuid],
+                                   lambda (some_uuid): (entity if some_uuid == ds_uuid
+                                                        else get_entity(some_uuid))
+                                   )
+        rules_json = calculate_assay_info(metadata,
+                                          is_human,
+                                          get_data_from_ubkg
+                                          )
+        return jsonify(rules_json)
     except ValueError as excp:
         logger.error(excp, exc_info=True)
         return Response("Bad parameter: {excp}", 400)
@@ -286,24 +247,12 @@ def get_assaytype_from_metadata():
     try:
         require_json(request)
         metadata = request.json
-        rules_json = calculate_assay_info(metadata)
-
         if parent_sample_ids := metadata.get("parent_sample_id"):
-            source_type = ""
-            parent_sample_ids = parent_sample_ids.split(",")
-            for parent_sample_id in parent_sample_ids:
-                parent_entity = get_entity(parent_sample_id)
-                if hasattr(parent_entity, "source"):
-                    if source_type := parent_entity.source.get("source_type"):
-                        # If there is a single Human source_type, treat this as a Human case
-                        if source_type.upper() == "HUMAN":
-                            break
-            apply_source_type_transformations(source_type, rules_json)
-
-        ubkg_value_json = get_data_from_ubkg(rules_json.get("ubkg_code")).get("value", {})
-        merged_json = standardize_results(rules_json, ubkg_value_json)
-        merged_json["ubkg_json"] = ubkg_value_json
-        return jsonify(merged_json)
+            is_human = source_is_human(parent_sample_ds.split(","), get_entity)
+        else:
+            is_human = True  # default to human for safety
+        rules_json = calculate_assay_info(metadata, is_human, get_data_from_ubkg)
+        return jsonify(rules_json)
     except ResponseException as re:
         logger.error(re, exc_info=True)
         return re.response

--- a/src/routes/assayclassifier/__init__.py
+++ b/src/routes/assayclassifier/__init__.py
@@ -287,7 +287,7 @@ def get_assaytype_from_metadata():
 @bp.route("/reload-assaytypes", methods=["PUT"])
 def reload_chain():
     try:
-        initialize_rule_chain()
+        initialize_rule_chains()
         return jsonify({})
     except ResponseException as re:
         logger.error(re, exc_info=True)

--- a/src/routes/assayclassifier/rule_chain.py
+++ b/src/routes/assayclassifier/rule_chain.py
@@ -29,30 +29,34 @@ class RuleLoader:
         assert format in ['yaml', 'json'], f"unknown format {format}"
         self.format = format
     def load(self):
-        rule_chain = RuleChain()
+        rule_chain_dict = {}
         if self.format == 'yaml':
-            json_recs = yaml.safe_load(self.stream)
+            json_dict = yaml.safe_load(self.stream)
         elif self.format == 'json':
             if isinstance(self.stream, str):
-                json_recs = json.loads(self.stream)
+                json_dict = json.loads(self.stream)
             else:
-                json_recs = json.load(self.stream)
+                json_dict = json.load(self.stream)
         else:
             raise RuntimeError(f"Unknown format {self.format} for input stream")
-        check_json_matches_schema(json_recs,
+        check_json_matches_schema(json_dict,
                                   SCHEMA_FILE,
                                   str(Path(__file__).parent),
                                   SCHEMA_BASE_URI)
-        for rec in json_recs:
-            for rule in [rec[key] for key in ['match', 'value']]:
-                assert Rule.is_valid(rule), f"Syntax error in rule string {rule}"
-            try:
-                rule_cls = {'note': NoteRule,
-                            'match': MatchRule}[rec['type'].lower()]
-            except KeyError:
-                raise RuleSyntaxException(f"Unknown rule type {rec['type']}")
-            rule_chain.add(rule_cls(rec['match'], rec['value']))
-        return rule_chain
+        for key in json_dict:
+            rule_chain = RuleChain()
+            json_recs = json_dict[key]
+            for rec in json_recs:
+                for rule in [rec[key2] for key2 in ['match', 'value']]:
+                    assert Rule.is_valid(rule), f"Syntax error in rule string {rule}"
+                try:
+                    rule_cls = {'note': NoteRule,
+                                'match': MatchRule}[rec['type'].lower()]
+                    rule_chain.add(rule_cls(rec['match'], rec['value']))
+                except KeyError:
+                    raise RuleSyntaxException(f"Unknown rule type {rec['type']}")
+            rule_chain_dict[key] = rule_chain
+        return rule_chain_dict
 
 
 class _RuleChainIter:
@@ -76,10 +80,10 @@ class RuleChain:
     def add(self, link):
         self.links.append(link)
     def dump(self, ofile):
-        print(f"START DUMP of {len(list(iter(self)))} rules")
+        ofile.write(f"START DUMP of {len(list(iter(self)))} rules\n")
         for idx, elt in enumerate(iter(self)):
-            print(f"{idx}: {elt}")
-        print(f"END DUMP of rules")
+            ofile.write(f"{idx}: {elt}\n")
+        ofile.write(f"END DUMP of rules\n")
     def __iter__(self):
         return _RuleChainIter(self)
     @classmethod
@@ -93,10 +97,12 @@ class RuleChain:
             return list(cls.cleanup(elt) for elt in val)
         else:
             return val
-    def apply(self, rec):
-        ctx = {}  # so rules can leave notes for later rules
+    def apply(self, rec, ctx = None):
+        if ctx is None:
+            ctx = {}  # so rules can leave notes for later rules
         for elt in iter(self):
-            #logger.debug(f"applying {elt} to rec:{rec}  ctx:{ctx}")
+            if ctx.get("DEBUG"):
+                logger.debug(f"applying {elt} to rec:{rec}  ctx:{ctx}")
             rec_dict = rec | ctx;
             try:
                 if elt.match_rule.matches(rec_dict):
@@ -109,8 +115,10 @@ class RuleChain:
                     else:
                         raise NotImplementedError(f"Unknown rule type {type(elt)}")
             except EngineError as excp:
-                print(f"ENGINE_ERROR {type(excp)} {excp}")
+                logger.error(f"ENGINE_ERROR {type(excp)} {excp}")
                 raise RuleLogicException(excp) from excp
+            if ctx.get("DEBUG"):
+                logger.debug("done")
         raise NoMatchException(f"No rule matched record {rec}")
 
 

--- a/src/routes/assayclassifier/rule_chain_schema.json
+++ b/src/routes/assayclassifier/rule_chain_schema.json
@@ -3,7 +3,7 @@
   "$id": "http://schemata.hubmapconsortium.org/rule_chain_schema.json",
   "title": "rule chain schema",
   "description": "rule chain schema",
-  "allOf":[{"$ref": "#/definitions/rule_chain"}],
+  "allOf":[{"$ref": "#/definitions/rule_chain_dict"}],
   "definitions": {
     "chain_record": {
       "type": "object",
@@ -32,6 +32,16 @@
     "rule_chain": {
       "type": "array",
       "items": { "$ref": "#/definitions/chain_record" }
+    },
+    "rule_chain_dict": {
+      "type": "object",
+      "properties": {
+	"pre": { "$ref": "#/definitions/rule_chain" },
+	"body": { "$ref": "#/definitions/rule_chain" },
+	"post": { "$re": "#/definitions/rule_chain" }
+      },
+      "required": ["body", "pre", "post"],
+      "additionalProperties": false
     }
   }
 }

--- a/src/routes/assayclassifier/source_is_human.py
+++ b/src/routes/assayclassifier/source_is_human.py
@@ -1,0 +1,67 @@
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+def merge_sources(source_type, this_source_type):
+    initial_source_type = source_type  # for diagnostics
+    if source_type is None:
+        source_type = this_source_type
+    elif source_type == this_source_type:
+        pass
+    else:
+        if this_source_type.upper() == "HUMAN":
+            source_type = "HUMAN"
+    LOGGER.debug(f"merge_sources {initial_source_type} + {this_source_type} -> {source_type}")
+    return source_type
+
+
+def source_is_human(entity_id_list, fetch_json_fun):
+    """
+    entity_id_list may be list of samples or datasets,
+    in uuid or HuBMAP/SENNET id form.
+    fetch_json_fun is a function with signature:
+
+        fetch_json_fun(entity_id: str) -> dict:
+
+    which returns a dict of entity information, where
+    entity_id can be a uuid or HuBMAP/SENNET ID specifying
+    a dataset, sample, or source.  Typically it fetches
+    the json by making a request of entity-api.
+
+    """
+    LOGGER.debug(f"source_is_human {entity_id_list}")
+    try:
+        source_type = None
+        for elt in entity_id_list:
+            entity_json = fetch_json_fun(elt)
+            assert "entity_type" in entity_json, "entity json has no entity_type"
+            entity_type = entity_json["entity_type"]
+            if entity_type.upper() == "SOURCE":
+                LOGGER.debug(f"{elt} is a Source")
+                assert "source_type" in entity_json, "source json has no source_type"
+                this_source_type = entity_json["source_type"]
+            elif entity_type.upper() == "SAMPLE":
+                LOGGER.debug(f"{elt} is a Sample")
+                assert "source" in entity_json, "source json has no source"
+                source = entity_json["source"]
+                assert "source_type" in source, "source.source json has no source_type"
+                this_source_type = source["source_type"]
+            elif entity_type.upper() == "DATASET":
+                LOGGER.debug(f"{elt} is a Dataset")
+                assert "sources" in entity_json, "dataset json has no sources"
+                this_source_type = None
+                for idx, source in enumerate(entity_json["sources"]):
+                    assert "source_type" in source, ("dataset.sources.source[{idx}]"
+                                                     " has no source_type")
+                    this_this_source_type = source["source_type"]
+                    this_source_type = merge_sources(this_source_type,
+                                                     this_this_source_type)
+            else:
+                raise AssertionError(f"Unsupported entity json type {entity_type}")
+
+            source_type = merge_sources(source_type, this_source_type)
+
+        return source_type.upper() == "HUMAN" # we trapped partial human earlier
+    except AssertionError as excp:
+        LOGGER.debug(f"AssertionError, assuming HUMAN: {excp}")
+        return True # fail safe

--- a/src/routes/assayclassifier/testing_rule_chain.json
+++ b/src/routes/assayclassifier/testing_rule_chain.json
@@ -1,52 +1,6 @@
-[
-    {
-        "type": "note",
-        "match": "metadata_schema_id == null",
-        "value": "{'not_dcwg': true, 'is_dcwg': false}",
-        "rule_description": "Preamble rule identifying DCWG"
-    },
-    {
-        "type": "note",
-        "match": "metadata_schema_id != null",
-        "value": "{'not_dcwg': false, 'is_dcwg': true}",
-        "rule_description": "Preamble rule identifying non-DCWG"
-    },
-    {
-        "type": "note",
-        "match": "creation_action == 'Create Dataset Activity' or creation_action == 'Multi-Assay Split' or (creation_action == null and (dataset_type != null or assay_type != null))",
-        "value": "{'is_primary': true}",
-        "rule_description": "Preamble rule identifying primary datasets"
-    },
-    {
-        "type": "note",
-        "match": "creation_action == 'Central Process'",
-        "value": "{'is_central_processed': true}",
-        "rule_description": "Preamble rule identifying centrally processed datasets"
-    },
-    {
-        "type": "note",
-        "match": "creation_action == 'Create Publication Activity' or dataset_type == 'Publication' or assay_type == 'publication'",
-        "value": "{'is_publication': true}",
-        "rule_description": "Preamble rule identifying publications"
-    },
-    {
-        "type": "note",
-        "match": "creation_action == 'Lab Process'",
-        "value": "{'is_lab_processed': true}",
-        "rule_description": "Preamble rule identifying lab processed datasets"
-    },
-    {
-        "type": "note",
-        "match": "not_dcwg and is_primary and version == null",
-        "value": "{'version': 0}",
-        "rule_description": "Cover default schema version = 0 for non-DCWG metadata"
-    },
-    {
-        "type": "note",
-        "match": "creation_action == 'External Process' or (parent_dataset_id != null and derived_dataset_type != null)",
-        "value": "{'is_epic': true}",
-        "rule_description": "Preamble rule identifying EPIC"
-    },
+{
+  "body":
+  [
     {
         "type": "match",
         "match": "not_dcwg and is_primary and assay_type in ['AF']",
@@ -524,7 +478,7 @@
     {
         "type": "match",
         "match": "is_dcwg and is_primary and dataset_type == 'GeoMx (NGS)'",
-        "value": "{'ubkg_code': 'C200760', 'assaytype': 'geomx_ngs?', 'vitessce-hints': [], 'dir-schema': 'geomx-ngs-v2', 'description': 'GeoMx (NGS)', 'contains-pii': true, 'primary': true, 'dataset-type': 'GeoMx (NGS)', 'must-contain': ['RNAseq (with probes)'], 'is-multi-assay': true}",
+        "value": "{'ubkg_code': 'C200760', 'assaytype': 'geomx_ngs?', 'vitessce-hints': [], 'dir-schema': 'geomx-ngs-v2', 'description': 'GeoMx (NGS)', 'contains-pii': true, 'primary': true, 'dataset-type': 'GeoMx (NGS)', 'must-contain': ['RNAseq'], 'is-multi-assay': true}",
         "rule_description": "DCWG geomx_ngs?"
     },
     {
@@ -692,7 +646,7 @@
     {
         "type": "match",
         "match": "is_dcwg and is_primary and dataset_type == '2D Imaging Mass Cytometry'",
-        "value": "{'ubkg_code': 'C201040', 'assaytype': 'IMC2D', 'vitessce-hints': [], 'dir-schema': 'imc-2d-v2', 'contains-pii': false, 'primary': true, 'dataset-type': '2D Imaging Mass Cytometry', 'description': '2D Imaging Mass Cytometry'}",
+        "value": "{'ubkg_code': 'C201040', 'assaytype': 'IMC2D', 'vitessce-hints': [], 'dir-schema': 'imc-v2', 'contains-pii': false, 'primary': true, 'dataset-type': '2D Imaging Mass Cytometry', 'description': '2D Imaging Mass Cytometry'}",
         "rule_description": "DCWG IMC2D"
     },
     {
@@ -782,7 +736,7 @@
     {
         "type": "match",
         "match": "is_epic and derived_dataset_type == 'Segmentation Mask'",
-        "value": "{'ubkg_code': 'C202020', 'assaytype': 'segmentation-mask', 'vitessce-hints': ['segmentation_mask', 'is_image', 'pyramid'], 'dir-schema': 'segmentation-mask-v2', 'contains-pii': false, 'primary': false, 'dataset-type': 'Segmentation Mask', 'description': 'Segmentation Mask', 'process_state': 'epic'}",
+        "value": "{'ubkg_code': 'C202020', 'assaytype': 'segmentation-mask', 'vitessce-hints': [], 'dir-schema': 'segmentation-mask-v2', 'contains-pii': false, 'primary': false, 'dataset-type': 'Segmentation Mask', 'description': 'Segmentation Mask', 'process_state': 'epic'}",
         "rule_description": "EPIC dataset segmentation mask"
     },
     {
@@ -793,7 +747,7 @@
     },
     {
         "type": "match",
-        "match": "is_dcwg and is_primary and dataset_type == 'RNAseq (with probes)' and oligo_probe_panel in ['10X Genomics; Chromium Next GEM Single Cell Fixed RNA Human Transcriptome Probe Kit, 64 rxns; PN 1000456', '10X Genomics; Chromium Next GEM Single Cell Fixed RNA Human Transcriptome Probe Kit, 16 rxns; PN 1000420', '10X Genomics; Chromium Next GEM Single Cell Fixed RNA, Mouse Transcriptome Probe Kit, 64 rxns; PN 1000492'] and assay_input_entity == 'single cell' and barcode_read =~~ 'Read 1' and barcode_size == 16 and barcode_offset == 0 and umi_read =~~ 'Read 1' and umi_size == 12 and umi_offset == 16",
+        "match": "is_dcwg and is_primary and dataset_type == 'RNAseq (with probes)' and oligo_probe_panel in ['10X Genomics; Chromium Next GEM Single Cell Fixed RNA Human Transcriptome Probe Kit, 64 rxns; PN 1000456', '10X Genomics; Chromium Next GEM Single Cell Fixed RNA Human Transcriptome Probe Kit, 16 rxns; PN 1000420'] and assay_input_entity == 'single cell' and barcode_read =~~ 'Read 1' and barcode_size == 16 and barcode_offset == 0 and umi_read =~~ 'Read 1' and umi_size == 12 and umi_offset == 16",
         "value": "{'ubkg_code': 'C202040', 'assaytype': 'scRNAseq-with-probes', 'vitessce-hints': [], 'dir-schema': 'rnaseq-with-probes-v2', 'contains-pii': true, 'primary': true, 'dataset-type': 'RNAseq (with probes)', 'description': 'RNAseq (with probes)'}",
         "rule_description": "DCWG scRNAseq-with-probes"
     },
@@ -802,11 +756,138 @@
         "match": "is_dcwg and is_primary and dataset_type == 'Xenium'",
         "value": "{'ubkg_code': 'C202050', 'assaytype': 'xenium', 'vitessce-hints': [], 'dir-schema': 'xenium-v2', 'contains-pii': true, 'primary': true, 'dataset-type': 'Xenium', 'description': 'Xenium'}",
         "rule_description": "DCWG xenium"
+    }
+  ],
+"pre":
+  [
+    {
+        "type": "note",
+        "match": "metadata_schema_id == null",
+        "value": "{'not_dcwg': true, 'is_dcwg': false}",
+        "rule_description": "Preamble rule identifying DCWG"
+    },
+    {
+        "type": "note",
+        "match": "metadata_schema_id != null",
+        "value": "{'not_dcwg': false, 'is_dcwg': true}",
+        "rule_description": "Preamble rule identifying non-DCWG"
+    },
+    {
+        "type": "note",
+        "match": "creation_action == 'Create Dataset Activity' or creation_action == 'Multi-Assay Split' or (creation_action == null and (dataset_type != null or assay_type != null))",
+        "value": "{'is_primary': true}",
+        "rule_description": "Preamble rule identifying primary datasets"
+    },
+    {
+        "type": "note",
+        "match": "creation_action == 'Central Process'",
+        "value": "{'is_central_processed': true}",
+        "rule_description": "Preamble rule identifying centrally processed datasets"
+    },
+    {
+        "type": "note",
+        "match": "creation_action == 'Create Publication Activity' or dataset_type == 'Publication' or assay_type == 'publication'",
+        "value": "{'is_publication': true}",
+        "rule_description": "Preamble rule identifying publications"
+    },
+    {
+        "type": "note",
+        "match": "creation_action == 'Lab Process'",
+        "value": "{'is_lab_processed': true}",
+        "rule_description": "Preamble rule identifying lab processed datasets"
+    },
+    {
+        "type": "note",
+        "match": "not_dcwg and is_primary and version == null",
+        "value": "{'version': 0}",
+        "rule_description": "Cover default schema version = 0 for non-DCWG metadata"
+    },
+    {
+        "type": "note",
+        "match": "creation_action == 'External Process' or (parent_dataset_id != null and derived_dataset_type != null)",
+        "value": "{'is_epic': true}",
+        "rule_description": "Preamble rule identifying EPIC"
     },
     {
         "type": "match",
-        "match": "is_central_processed and data_types[0] in ['kaggle_2_segmentation']",
-        "value": "{'ubkg_code': 'C202060', 'assaytype': 'h-and-e', 'vitessce-hints': [], 'primary': false, 'contains-pii': false, 'description': 'H&E Stained Microscopy [Kaggle-2 Segmentation]', 'pipeline-shorthand': 'Kaggle-2 Segmentation'}",
-        "rule_description": "derived h-and-e"
+        "match": "true",
+        "value": "{'not_dcwg': not_dcwg, 'is_dcwg': is_dcwg, 'is_primary': is_primary, 'is_central_processed': is_central_processed, 'is_publication': is_publcation, 'is_lab_processed': is_lab_processed, 'version': version, 'is_epic': is_epic}",
+        "rule_description": "return expected values from preamble"
     }
-]
+  ],
+"post":
+  [
+    {
+        "type": "note",
+        "match": "true",
+        "value": "{'final_contains_pii': (source_is_human and values['contains-pii'])}",
+        "rule_description": "non-human data is not PII"
+    },
+    {
+        "type": "note",
+        "match": "true",
+        "value": "{'final_vitessce_hints': (ubkg_values&['vitessce_hints'] ? ubkg_values&['vitessce_hints'] : values&['vitessce-hints'])}",
+        "rule_description": "use UBKG vitessce_hints if available"
+    },
+    {
+        "type": "note",
+        "match": "true",
+        "value": "{'final_assaytype': (ubkg_values&['assaytype'] ? ubkg_values&['assaytype'] : values&['assaytype'])}",
+        "rule_description": "use UBKG assaytype if available"
+    },
+    {
+        "type": "note",
+        "match": "true",
+        "value": "{'final_dir_schema': (ubkg_values&['dir_schema'] ? ubkg_values&['dir_schema'] : values&['dir-schema'])}",
+        "rule_description": "use UBKG dir_schema if available"
+    },
+    {
+        "type": "note",
+        "match": "true",
+        "value": "{'final_primary': (ubkg_values&['primary'] ? ubkg_values&['primary'] : values&['primary'])}",
+        "rule_description": "use UBKG primary if available"
+    },
+    {
+        "type": "note",
+        "match": "true",
+        "value": "{'final_dataset_type': (ubkg_values&['dataset_type'] ? ubkg_values&['dataset_type'] : values&['dataset-type'])}",
+        "rule_description": "use UBKG dataset_type if available"
+    },
+    {
+        "type": "note",
+        "match": "true",
+        "value": "{'final_description': (ubkg_values&['description'] ? ubkg_values&['description'] : values&['description'])}",
+        "rule_description": "use UBKG description if available"
+    },
+    {
+        "type": "note",
+        "match": "true",
+        "value": "{'final_must_contain': (ubkg_values&['must_contain'] ? ubkg_values&['must_contain'] : values&['must-contain'])}",
+        "rule_description": "use UBKG must_contain if available"
+    },
+    {
+        "type": "note",
+        "match": "true",
+        "value": "{'final_is_multi_assay': (ubkg_values&['is_multi_assay'] ? ubkg_values&['is_multi_assay'] : values&['is-multi-assay'])}",
+        "rule_description": "use UBKG must_contain if available"
+    },
+    {
+        "type": "note",
+        "match": "true",
+        "value": "{'final_pipeline_shorthand': (ubkg_values&['pipeline_shorthand'] ? ubkg_values&['pipeline_shorthand'] : values&['pipeline-shorthand'])}",
+        "rule_description": "use UBKG must_contain if available"
+    },
+    {
+        "type": "note",
+        "match": "true",
+        "value": "{'final_tbl_schema': (ubkg_values&['tbl_schema'] ? ubkg_values&['tbl_schema']+pre_values['version'].to_str : values&['tbl-schema'])}",
+        "rule_description": "use UBKG must_contain if available"
+    },
+    {
+        "type": "match",
+        "match": "true",
+        "value": "{'contains-pii': final_contains_pii, 'vitessce-hints': final_vitessce_hints, 'assaytype': final_assaytype, 'dir-schema': final_dir_schema, 'primary': final_primary, 'dataset-type': final_dataset_type, 'description': final_description, 'must-contain': final_must_contain, 'is-multi-assay': final_is_multi_assay, 'pipeline-shorthand': final_pipeline_shorthand, 'tbl-schema': final_tbl_schema, 'ubkg_code': values&['ubkg_code']}",
+        "rule_description": "return expected values"
+    }
+  ]
+}


### PR DESCRIPTION
This PR breaks the assayclassifier rule chain into separate segments for pre- and post-processing in addition to the main 'body' rules.  This permits moving much of the logic that was hard-coded in the previous version into the rule chains themselves.
The rule chain schema is updated correspondingly.  A separate module is added for a generic source_is_human() function designed to work consistently across HuBMAP and SENNET.