### PR TITLE
reference final PII off UBKG

### DIFF
--- a/src/routes/assayclassifier/testing_rule_chain.json
+++ b/src/routes/assayclassifier/testing_rule_chain.json
@@ -916,7 +916,7 @@
     {
         "type": "note",
         "match": "true",
-        "value": "{'final_contains_pii': (source_is_human and values['contains-pii'])}",
+        "value": "{'final_contains_pii': (source_is_human and (ubkg_values&['contains_full_genetic_sequences'] ? ubkg_values&['contains_full_genetic_sequences'] : values&['contains-pii']))}",
         "rule_description": "non-human data is not PII"
     },
     {


### PR DESCRIPTION
This updates the rule chain rule which determines the final contains-human-genetic-sequences state to respect the UBKG version of the assay's state over the rule chain's version if they differ.